### PR TITLE
refactor: Eliminate "eternal blocking" case

### DIFF
--- a/actfw_gstreamer/capture.py
+++ b/actfw_gstreamer/capture.py
@@ -91,7 +91,7 @@ class GstreamerCapture(Producer):  # type: ignore
                     if (time.time() - no_sample_start) > connection_lost_threshold:
                         raise ConnectionLostError()
 
-                value = stream.capture(timeout=1000)
+                value = stream.capture(timeout_secs=1)
                 if value is None:
                     if no_sample_start is None:
                         no_sample_start = time.time()

--- a/actfw_gstreamer/gstreamer/stream.py
+++ b/actfw_gstreamer/gstreamer/stream.py
@@ -77,8 +77,8 @@ class _GstStream:
 
     # Here, Any = ConverterBase::ConvertResult, but we can't yet express associated types.
     # c.f. https://github.com/python/mypy/issues/7790
-    def capture(self, timeout: float) -> Any:
-        res = self._inner.capture(timeout)
+    def capture(self, timeout_secs: float) -> Any:
+        res = self._inner.capture(timeout_secs)
         if res.is_ok():
             return res.unwrap()
         else:
@@ -156,12 +156,10 @@ class Inner:
         else:
             return Ok()
 
-    def capture(self, timeout: float) -> Result[Optional[Any], Exception]:
-        timeout = timeout / 1000
-
+    def capture(self, timeout_secs: float) -> Result[Optional[Any], Exception]:
         im: Optional[InternalMessage]
         try:
-            im = self._queue.get(block=True, timeout=timeout)
+            im = self._queue.get(block=True, timeout=timeout_secs)
         except Empty:
             im = None
 


### PR DESCRIPTION
Other `Capture` classes in `actfw-*` are not eternal-blocking. `GstCapture` is too, but the code did not enforce it.